### PR TITLE
Cannot download sbt tgz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SBT_VERSION=1.3.8
 
 RUN apk update && \
   apk add --no-cache openjdk11-jre-headless curl bash && \
-  curl -L -o sbt-${SBT_VERSION}.tgz https://piccolo.link/sbt-${SBT_VERSION}.tgz && \
+  curl -L -o sbt-${SBT_VERSION}.tgz https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz && \
   tar -xvzf sbt-${SBT_VERSION}.tgz && \
   rm sbt-${SBT_VERSION}.tgz
 


### PR DESCRIPTION
Thanks for your [blog article](https://medium.com/@terfno/alpine%E3%83%99%E3%83%BC%E3%82%B9%E3%81%AEsbt%E3%81%8C%E4%BD%BF%E3%81%88%E3%82%8Bdocker%E3%82%A4%E3%83%A1%E3%83%BC%E3%82%B8%E3%82%92%E4%BD%9C%E3%82%8B-4d94cffe0fd8).
I tried to use it but could not download sbt tgz.
The official documentation said to download it via the GitHub release.